### PR TITLE
add rclone --drive-shared-with-me flag for shared folder

### DIFF
--- a/scripts/download_scripts/download_NCI_data.sh
+++ b/scripts/download_scripts/download_NCI_data.sh
@@ -12,6 +12,8 @@ OUTFILE=${OUTDIR}/NCI_v2.txt
 
 mkdir -p $OUTDIR
 
+# @JF you will need to removed the shared option and adjust the path to Theme A DCU
+
 if [[ -n $(rclone lsf --drive-shared-with-me "gdrive:Theme A DCU" 2> /dev/null) ]]; then
     THEME_A_DCU="gdrive:Theme A DCU"
 else

--- a/scripts/download_scripts/download_NCI_data.sh
+++ b/scripts/download_scripts/download_NCI_data.sh
@@ -12,10 +12,10 @@ OUTFILE=${OUTDIR}/NCI_v2.txt
 
 mkdir -p $OUTDIR
 
-if [[ -n $(rclone lsf "gdrive:Theme A DCU" 2> /dev/null) ]]; then
+if [[ -n $(rclone lsf --drive-shared-with-me "gdrive:Theme A DCU" 2> /dev/null) ]]; then
     THEME_A_DCU="gdrive:Theme A DCU"
 else
-    if [[ -n $(rclone lsf "gdrive:Theme A/Theme A DCU" 2> /dev/null) ]]; then
+    if [[ -n $(rclone lsf --drive-shared-with-me "gdrive:Theme A/Theme A DCU" 2> /dev/null) ]]; then
         THEME_A_DCU="gdrive:Theme A/Theme A DCU"
     else
         echo "Theme A DCU folder not found"
@@ -23,7 +23,7 @@ else
     fi
 fi
 
-rclone cat \
+rclone cat --drive-shared-with-me \
     "${THEME_A_DCU}/Irish_Data/ForasNaGaeilge/9MqDsdf834ms2NfS8L2joi7u_NCIv2.vert" \
     --bwlimit 1000M --transfers 1 | \
     scripts/extract_text_from_nci_vert.py --document-newline | \

--- a/scripts/download_scripts/download_gdrive_data.sh
+++ b/scripts/download_scripts/download_gdrive_data.sh
@@ -8,7 +8,7 @@ echo "Downloading data from Google Drive ..."
 OUTDIR=data/ga/gdrive
 mkdir -p $OUTDIR
 
-rclone copy "gdrive:Theme A DCU/Irish_Data/" $OUTDIR --bwlimit 1000M --transfers 1
+rclone copy --drive-shared-with-me "gdrive:Theme A DCU/Irish_Data/" $OUTDIR --bwlimit 1000M --transfers 1
 
 echo "Done"
 

--- a/scripts/download_scripts/download_gdrive_data.sh
+++ b/scripts/download_scripts/download_gdrive_data.sh
@@ -8,6 +8,8 @@ echo "Downloading data from Google Drive ..."
 OUTDIR=data/ga/gdrive
 mkdir -p $OUTDIR
 
+# @JF you will need to removed the shared option and adjust the path to Theme A DCU
+
 rclone copy --drive-shared-with-me "gdrive:Theme A DCU/Irish_Data/" $OUTDIR --bwlimit 1000M --transfers 1
 
 echo "Done"

--- a/scripts/download_scripts/download_gdrive_filelist.sh
+++ b/scripts/download_scripts/download_gdrive_filelist.sh
@@ -7,6 +7,8 @@ echo "Downloading filelist from Google Drive ..."
 
 OUTDIR=data/ga/gdrive
 
+# @JF you will need to removed the shared option and adjust the path to Theme A DCU
+
 rclone copy --drive-shared-with-me "gdrive:Theme A DCU/Irish_Data/gdrive_filelist.csv" $OUTDIR
 
 echo "Done"

--- a/scripts/download_scripts/download_gdrive_filelist.sh
+++ b/scripts/download_scripts/download_gdrive_filelist.sh
@@ -7,6 +7,6 @@ echo "Downloading filelist from Google Drive ..."
 
 OUTDIR=data/ga/gdrive
 
-rclone copy "gdrive:Theme A DCU/Irish_Data/gdrive_filelist.csv" $OUTDIR
+rclone copy --drive-shared-with-me "gdrive:Theme A DCU/Irish_Data/gdrive_filelist.csv" $OUTDIR
 
 echo "Done"

--- a/scripts/download_scripts/download_oscar_data.sh
+++ b/scripts/download_scripts/download_oscar_data.sh
@@ -5,10 +5,10 @@
 OUTDIR=data/ga/oscar/raw
 FILENAME=oscar-ga-unshuffled.tar.bz2
 
-if [[ -n $(rclone lsf "gdrive:Theme A DCU" 2> /dev/null) ]]; then
+if [[ -n $(rclone lsf --drive-shared-with-me "gdrive:Theme A DCU" 2> /dev/null) ]]; then
     THEME_A_DCU="gdrive:Theme A DCU"
 else
-    if [[ -n $(rclone lsf "gdrive:Theme A/Theme A DCU" 2> /dev/null) ]]; then
+    if [[ -n $(rclone lsf --drive-shared-with-me "gdrive:Theme A/Theme A DCU" 2> /dev/null) ]]; then
         THEME_A_DCU="gdrive:Theme A/Theme A DCU"
     else
         echo "Theme A DCU folder not found"
@@ -22,7 +22,7 @@ if [ -s "$OUTDIR" ]; then
 else
     mkdir -p ${OUTDIR}
     echo $'\n'"Downloading Oscar data for ga..."$'\n'
-    rclone copy "${THEME_A_DCU}/ga_BERT/BERT_Preprocessing/raw-corpora/${FILENAME}" $OUTDIR --bwlimit 1000M --transfers 1
+    rclone copy --drive-shared-with-me "${THEME_A_DCU}/ga_BERT/BERT_Preprocessing/raw-corpora/${FILENAME}" $OUTDIR --bwlimit 1000M --transfers 1
     if [ -f "${OUTDIR}/${FILENAME}" ]; then
         # unzip/untar download
         cd ${OUTDIR}

--- a/scripts/download_scripts/download_oscar_data.sh
+++ b/scripts/download_scripts/download_oscar_data.sh
@@ -5,6 +5,8 @@
 OUTDIR=data/ga/oscar/raw
 FILENAME=oscar-ga-unshuffled.tar.bz2
 
+# @JF you will need to removed the shared option and adjust the path to Theme A DCU
+
 if [[ -n $(rclone lsf --drive-shared-with-me "gdrive:Theme A DCU" 2> /dev/null) ]]; then
     THEME_A_DCU="gdrive:Theme A DCU"
 else

--- a/scripts/download_scripts/download_sampleNCI_data.sh
+++ b/scripts/download_scripts/download_sampleNCI_data.sh
@@ -21,6 +21,8 @@ mkdir -p $OUTDIR
 
 echo "Locating data on Google Drive ..."
 
+# @JF you will need to removed the shared option and adjust the path to Theme A DCU
+
 if [[ -n $(rclone lsf --drive-shared-with-me "gdrive:Theme A DCU" 2> /dev/null) ]]; then
     THEME_A_DCU="gdrive:Theme A DCU"
 else

--- a/scripts/download_scripts/download_sampleNCI_data.sh
+++ b/scripts/download_scripts/download_sampleNCI_data.sh
@@ -21,10 +21,10 @@ mkdir -p $OUTDIR
 
 echo "Locating data on Google Drive ..."
 
-if [[ -n $(rclone lsf "gdrive:Theme A DCU" 2> /dev/null) ]]; then
+if [[ -n $(rclone lsf --drive-shared-with-me "gdrive:Theme A DCU" 2> /dev/null) ]]; then
     THEME_A_DCU="gdrive:Theme A DCU"
 else
-    if [[ -n $(rclone lsf "gdrive:Theme A/Theme A DCU" 2> /dev/null) ]]; then
+    if [[ -n $(rclone lsf --drive-shared-with-me "gdrive:Theme A/Theme A DCU" 2> /dev/null) ]]; then
         THEME_A_DCU="gdrive:Theme A/Theme A DCU"
     else
         echo "Theme A DCU folder not found"
@@ -44,7 +44,7 @@ done
 
 echo "Downloading data from Google Drive ..."
 
-rclone cat \
+rclone cat --drive-shared-with-me \
     "${THEME_A_DCU}/Irish_Data/ForasNaGaeilge/9MqDsdf834ms2NfS8L2joi7u_NCIv2.vert" \
     --bwlimit 1000M --transfers 1 | \
     scripts/extract_text_from_nci_vert.py | \

--- a/scripts/download_scripts/download_twitter_data.sh
+++ b/scripts/download_scripts/download_twitter_data.sh
@@ -9,10 +9,10 @@ echo "Downloading twitter data from Google Drive ..."
 OUTDIR=data/ga/twitter/raw
 mkdir -p $OUTDIR
 
-if [[ -n $(rclone lsf "gdrive:Theme A DCU" 2> /dev/null) ]]; then
+if [[ -n $(rclone lsf --drive-shared-with-me "gdrive:Theme A DCU" 2> /dev/null) ]]; then
     THEME_A_DCU="gdrive:Theme A DCU"
 else
-    if [[ -n $(rclone lsf "gdrive:Theme A/Theme A DCU" 2> /dev/null) ]]; then
+    if [[ -n $(rclone lsf --drive-shared-with-me "gdrive:Theme A/Theme A DCU" 2> /dev/null) ]]; then
         THEME_A_DCU="gdrive:Theme A/Theme A DCU"
     else
         echo "Theme A DCU folder not found"
@@ -20,7 +20,7 @@ else
     fi
 fi
 
-rclone copy "gdrive:Theme A DCU/Irish_Data/Tweets/" $OUTDIR --bwlimit 1000M --transfers 1
+rclone copy --drive-shared-with-me "gdrive:Theme A DCU/Irish_Data/Tweets/" $OUTDIR --bwlimit 1000M --transfers 1
 
 cd $OUTDIR
 rm README.md

--- a/scripts/download_scripts/download_twitter_data.sh
+++ b/scripts/download_scripts/download_twitter_data.sh
@@ -9,6 +9,8 @@ echo "Downloading twitter data from Google Drive ..."
 OUTDIR=data/ga/twitter/raw
 mkdir -p $OUTDIR
 
+# @JF you will need to removed the shared option and adjust the path to Theme A DCU
+
 if [[ -n $(rclone lsf --drive-shared-with-me "gdrive:Theme A DCU" 2> /dev/null) ]]; then
     THEME_A_DCU="gdrive:Theme A DCU"
 else


### PR DESCRIPTION
Address issue #112.

Google changed the behaviour of shared folders a few times over the last years. The "Add to drive" trick to make shared folders accessible in `rclone` no longer works.

This PR adds `--drive-shared-with-me` to all our download scripts. Unfortunately, this breaks access for the owner of the "Theme A DCU" folder, Jennifer, if it is not already broken for her, e.g. if "Theme A DCU" is not in her root folder. Adding code to omit `--drive-shared-with-me` when she runs the script is probably not enough as the path to "Theme A DCU" probably must also be adjusted. I'd just leave it broken for Jennifer for now and she will figure out what's wrong when she tries to run these scripts. By the time something else may have changed and render the scripts non-functional anyway.

We can then release v0.1.1 so that team members downloading the current release do not run into this problem. (Outsiders won't have access to the folder anyway.)